### PR TITLE
fix: inconsistent conditional result types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "cloudflare_record" "record" {
-  for_each = var.module_enabled ? local.records : tomap({})
+  for_each = var.module_enabled ? local.records : null
 
   zone_id         = cloudflare_zone.zone[0].id
   name            = each.value.name


### PR DESCRIPTION
Issue:

```bash
terraform plan
╷
│ Error: Inconsistent conditional result types
│ 
│   on .terraform/modules/terraform-cloudflare-dns/main.tf line 20, in resource "cloudflare_record" "record":
│   20:   for_each = merge({}, var.module_enabled ? local.records : {})
│     ├────────────────
│     │ local.records is object with 52 attributes
│     │ var.module_enabled is true
│ 
│ The true and false result expressions must have consistent types. The given expressions are object and object, respectively.
```

All credits go to @maartenvanderhoef!